### PR TITLE
Create sad path error messages for users

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -45,8 +45,8 @@
           <button class="remove-recipe modal-recipe-btn hidden" id="remove">
             <img class="bookmark-img" src="./images/select-bookmark-icon.png" id="remove">
           </button>
-          <img class="close-btn" id="closeRecipeSmall" src="delete.png"></img>
           <p class="modal-feedback"></p>
+          <img class="close-btn" id="closeRecipeSmall" src="delete.png"></img>
         </div>
         <div id="recipeName"></div>
         <article id="recipeInstructions">

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -115,37 +115,24 @@ const updateCurrentUser = (user) => {
   currentUser = user;
 };
 
-const postRecipeToCook = (userID, recipeID, e) => {
-  updateRecipe(userID, recipeID, "POST")
-    .then((res) => res.json())
-    .then(status => {
-      if (status.message.includes("was added")) {
-        getUsersAfterUpdate(userID, recipeID, e);
-      } else {
-        showError(recipeID)
-      }
-    })
-    .catch(err => {
-      showError(recipeID);
-      console.error(err);
-    });
-}
-
-const deleteRecipeToCook = (userID, recipeID, e) => {
-  updateRecipe(userID, recipeID, "DELETE")
-    .then((res) => res.json())
-    .then(status => {
-      if (status.message.includes("was removed")) {
-        console.log("here")
-        getUsersAfterUpdate(userID, recipeID, e);
-      } else {
-        showError(recipeID);
-      }
-    })
-    .catch(err => {
-      showError(recipeID);
-      console.error(err)
-    });
+const updateServerRecipe = (userID, recipeID, e, requestType) => {
+  const conditions = {
+    "POST": 'added',
+    "DELETE": 'removed'
+  }
+  updateRecipe(userID, recipeID, requestType)
+  .then((res) => res.json())
+  .then(status => {
+    if (status.message.includes(`was ${conditions[requestType]}`)) {
+      getUsersAfterUpdate(userID, recipeID, e);
+    } else {
+      showError(recipeID)
+    }
+  })
+  .catch(err => {
+    showError(recipeID);
+    console.error(err);
+  });
 }
 
 // Chat GPT Extension 
@@ -180,4 +167,4 @@ const getChatGPTRecipePitches = (allRecipes) => {
   });
 }
 
-export { currentUser, pageData, updateCurrentUser, loadData, patchHits, postRecipeToCook, deleteRecipeToCook };
+export { currentUser, pageData, updateCurrentUser, loadData, patchHits, updateServerRecipe };

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -122,12 +122,12 @@ const postRecipeToCook = (userID, recipeID, e) => {
       if (status.message.includes("was added")) {
         getUsersAfterUpdate(userID, recipeID, e);
       } else {
-        showError()
+        showError(recipeID)
       }
     })
     .catch(err => {
+      showError(recipeID);
       console.error(err);
-      showError();
     });
 }
 
@@ -138,12 +138,12 @@ const deleteRecipeToCook = (userID, recipeID, e) => {
       if (status.message.includes("was added")) {
         getUsersAfterUpdate(userID, recipeID, e);
       } else {
-        showError();
+        showError(recipeID);
       }
     })
     .catch(err => {
+      showError(recipeID);
       console.error(err)
-      showError();
     });
 }
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -135,7 +135,8 @@ const deleteRecipeToCook = (userID, recipeID, e) => {
   updateRecipe(userID, recipeID, "DELETE")
     .then((res) => res.json())
     .then(status => {
-      if (status.message.includes("was added")) {
+      if (status.message.includes("was removed")) {
+        console.log("here")
         getUsersAfterUpdate(userID, recipeID, e);
       } else {
         showError(recipeID);

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,6 +1,13 @@
 //IMPORTS 
 import { getRandomUser } from "./users";
-import { pageLoadRenders, hideSpinner, toggleSavedButtons, renderTagsAfterFetch } from "./domUpdates";
+import {
+  pageLoadRenders,
+  hideSpinner,
+  toggleSavedButtons,
+  renderTagsAfterFetch,
+  checkIfModalOpen,
+  showError
+ } from "./domUpdates";
 import { copyItem } from "./helper-functions";
 import { populateTags } from './recipes';
 // import { config } from "../config.js"
@@ -31,16 +38,15 @@ const updateRecipe = (userID, recipeID, request) => {
   }})
 }
 
-const getUsersAfterUpdate = (userID, recipeID, e) => {
+const getUsersAfterUpdate = (userID, recipeID, e, errorMessage) => {
   return getUsers()
           .then(response => {
-            if(response.message) {console.log("get response",response.message)}
             return response.json();
           })
           .then(data => {
             const foundUser = data.users.find(user => user.id === userID);
             currentUser = foundUser;
-            toggleSavedButtons(e, recipeID, currentUser);
+            toggleSavedButtons(e, recipeID, currentUser, errorMessage);
             renderTagsAfterFetch();
           })
           .catch(err => console.error(err))
@@ -69,8 +75,11 @@ const patchHits = (recipe) => {
       'Content-Type': 'application/json'
     }
   })
-    .then(res => res.json())
-    .then(() => {
+    .then(res => {
+      return res.json()
+    })
+    .then((status) => {
+      if (!status.message.includes("Success")) console.log(status.message)
       getRecipes()
         .then(res => res.json())
         .then(data => {
@@ -108,20 +117,34 @@ const updateCurrentUser = (user) => {
 
 const postRecipeToCook = (userID, recipeID, e) => {
   updateRecipe(userID, recipeID, "POST")
-    .then((res) => {
-      if (res.message) {console.log("post response", res.message)}
-      getUsersAfterUpdate(userID, recipeID, e);
+    .then((res) => res.json())
+    .then(status => {
+      if (status.message.includes("was added")) {
+        getUsersAfterUpdate(userID, recipeID, e);
+      } else {
+        showError()
+      }
     })
-    .catch(err => console.error(err));
+    .catch(err => {
+      console.error(err);
+      showError();
+    });
 }
 
 const deleteRecipeToCook = (userID, recipeID, e) => {
   updateRecipe(userID, recipeID, "DELETE")
-    .then((res) => {
-      if (res.message) {console.log("delete response", res.message)}
-      getUsersAfterUpdate(userID, recipeID, e);
+    .then((res) => res.json())
+    .then(status => {
+      if (status.message.includes("was added")) {
+        getUsersAfterUpdate(userID, recipeID, e);
+      } else {
+        showError();
+      }
     })
-    .catch(err => console.error(err));
+    .catch(err => {
+      console.error(err)
+      showError();
+    });
 }
 
 // Chat GPT Extension 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -424,7 +424,7 @@ const updateRecipesFromModal = (e) => {
 
 const checkIfModalOpen = () => allRecipes.classList.contains('blur')
 
-const showError = () => {
+const showError = (recipeID) => {
   if (checkIfModalOpen()){
     showModalFeedback("Something went wrong")
   } else {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -424,6 +424,14 @@ const updateRecipesFromModal = (e) => {
 
 const checkIfModalOpen = () => allRecipes.classList.contains('blur')
 
+const showError = () => {
+  if (checkIfModalOpen()){
+    showModalFeedback("Something went wrong")
+  } else {
+    showGridFeedback(recipeID, "Something went wrong")
+  }
+}
+
 const toggleSavedButtons = (e, recipeID, user) => {
   if (checkIfModalOpen()) {
     const outerAdd = pageData.currentRecipeCard.outerAddBtn;
@@ -469,5 +477,6 @@ export {
   renderRecipesOfInterest,
   enableScrollPitchText,
   toggleSavedButtons,
-  checkIfModalOpen
+  checkIfModalOpen,
+  showError
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -525,7 +525,7 @@ input[type=checkbox] {
   color: #fbbf83;
   font-size: 1em;
   opacity: 0;
-  max-width: 170px;
+  min-width: 170px;
 }
 
 .show-feedback {

--- a/src/styles.css
+++ b/src/styles.css
@@ -525,6 +525,7 @@ input[type=checkbox] {
   color: #fbbf83;
   font-size: 1em;
   opacity: 0;
+  max-width: 170px;
 }
 
 .show-feedback {

--- a/src/users.js
+++ b/src/users.js
@@ -1,5 +1,5 @@
 import { getRandomIndex } from "./helper-functions";
-import { currentUser, postRecipeToCook, deleteRecipeToCook } from "./apiCalls";
+import { currentUser, updateServerRecipe } from "./apiCalls";
 
 const getRandomUser = users => {
   return users[getRandomIndex(users)]
@@ -7,14 +7,14 @@ const getRandomUser = users => {
 
 const addUniqueRecipe = (userRecipes, newRecipe, e) => {
   if(!userRecipes.find(recipeID => recipeID.toString() === newRecipe.id.toString())) {
-    postRecipeToCook(currentUser.id, newRecipe.id, e);
+    updateServerRecipe(currentUser.id, newRecipe.id, e, "POST");
   }
 };
 
 const removeExistingRecipe = (userRecipes, recipeToRemove, e) => {
   let found = userRecipes.find(recipeID => recipeID.toString() === recipeToRemove.id.toString());
   if (found) {
-    deleteRecipeToCook(currentUser.id, recipeToRemove.id, e)
+    updateServerRecipe(currentUser.id, recipeToRemove.id, e, "DELETE")
   }
 }
 


### PR DESCRIPTION
Description
- Created relevant error displays for if our API's fail. 
- The error for PATCH is only in the console because that does not affect user's experience but will be of interest for the developer.
- The error for POST and DELETE are being displayed both on the grid and the modal. Earlier, user got a feedback confirming happy path. Now user gets sad path feedback too. 
- Our functions are stringent with conditionals so we've already prevented all imaginable sad paths. So for this PR's purpose: consider any path that does not get a success status message from our server. 
- Adding to the stringent conditions, our happy path functions are ONLY going to be invoked if the status message in the response confirms success (I referred to the response messages and checked for expected substrings in success). 
- All tests still passing

Testing Notes
- Load the web app and once loaded, close the server from your terminal. Then try adding/deleting a recipe. The add/minus should not change and relevant feedback should appear. The recipe should not appear in saved recipes either.
- Try the same again from within the modal (close the server only once you're inside the modal view. After closing the server, try bookmarking the recipe).
- Try both adding/deleting
- Try from grid and modal
- Try from different screen sizes.
