### PR TITLE
Fix the bug when recipe was clicked

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -6,7 +6,8 @@ import {
   toggleSavedButtons,
   renderTagsAfterFetch,
   checkIfModalOpen,
-  showError
+  showError,
+  showFeedback
  } from "./domUpdates";
 import { copyItem } from "./helper-functions";
 import { populateTags } from './recipes';
@@ -48,6 +49,7 @@ const getUsersAfterUpdate = (userID, recipeID, e, errorMessage) => {
             currentUser = foundUser;
             renderTagsAfterFetch();
             toggleSavedButtons(e, recipeID, currentUser, errorMessage);
+            showFeedback(currentUser, recipeID)
           })
           .catch(err => console.error(err))
 }

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -227,18 +227,22 @@ const updateCurrentRecipe = recipeCard => {
 
 const showGridFeedback = (recipeID, feedback) => {
   const recipe = document.getElementById(recipeID);
-  const gridFeedback = recipe.querySelector('.grid-feedback');
-  gridFeedback?.innerText = feedback;
-  gridFeedback?.classList?.add('show-feedback');
-  setTimeout(() => {gridFeedback.classList?.remove('show-feedback')}, 751);
+  if (recipe) {
+    const gridFeedback = recipe.querySelector('.grid-feedback');
+    gridFeedback.innerText = feedback;
+    gridFeedback.classList.add('show-feedback');
+    setTimeout(() => {gridFeedback.classList.remove('show-feedback')}, 751);
+  }
 }
 
 
 const showModalFeedback = (feedback) => {
   let modalFeedback = document.querySelector('.modal-feedback');
-  modalFeedback?.innerText = feedback
-  modalFeedback?.classList.add('show-feedback');
-  setTimeout(() => {modalFeedback?.classList.remove('show-feedback')}, 751)
+  if (modalFeedback) {
+    modalFeedback.innerText = feedback
+    modalFeedback.classList.add('show-feedback');
+    setTimeout(() => {modalFeedback.classList.remove('show-feedback')}, 751)
+  }
 }
 
 const showFeedback = (user, recipeID) => {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -227,25 +227,21 @@ const updateCurrentRecipe = recipeCard => {
 
 const showGridFeedback = (recipeID, feedback) => {
   const recipe = document.getElementById(recipeID);
-  const gridFeedback = recipe?.querySelector('.grid-feedback');
-  gridFeedback.innerText = feedback;
-  gridFeedback.classList?.add('show-feedback');
+  const gridFeedback = recipe.querySelector('.grid-feedback');
+  gridFeedback?.innerText = feedback;
+  gridFeedback?.classList?.add('show-feedback');
   setTimeout(() => {gridFeedback.classList?.remove('show-feedback')}, 751);
 }
 
 
 const showModalFeedback = (feedback) => {
   let modalFeedback = document.querySelector('.modal-feedback');
-  modalFeedback.innerText = feedback
-  modalFeedback.classList.add('show-feedback');
-  setTimeout(() => {modalFeedback.classList.remove('show-feedback')}, 751)
+  modalFeedback?.innerText = feedback
+  modalFeedback?.classList.add('show-feedback');
+  setTimeout(() => {modalFeedback?.classList.remove('show-feedback')}, 751)
 }
 
 const showFeedback = (user, recipeID) => {
-  const unacceptableView = pageData.currentView === "your-recipes" && !checkIfModalOpen();
-  const acceptableView = !unacceptableView;
-
-  if (acceptableView) {
     let view;
     let feedback; 
     
@@ -265,9 +261,8 @@ const showFeedback = (user, recipeID) => {
     } else {
       view = "grid";
     }
-    
+
     feedbacks[view]();
-  }
 }
 
 const updateSaveButtons = (recipeID, addButton, removeButton, user) => {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -233,6 +233,7 @@ const showGridFeedback = (recipeID, feedback) => {
   setTimeout(() => {gridFeedback.classList?.remove('show-feedback')}, 751);
 }
 
+
 const showModalFeedback = (feedback) => {
   let modalFeedback = document.querySelector('.modal-feedback');
   modalFeedback.innerText = feedback
@@ -240,31 +241,44 @@ const showModalFeedback = (feedback) => {
   setTimeout(() => {modalFeedback.classList.remove('show-feedback')}, 751)
 }
 
-const updateSaveButtons = (recipeID, addButton, removeButton, user) => {
-  let view;
-  let feedback; 
-  if (checkIfModalOpen()) {
-    view = "modal";
-  } else {
-    view = "grid";
-  }
+const showFeedback = (user, recipeID) => {
+  const unacceptableView = pageData.currentView === "your-recipes" && !checkIfModalOpen();
+  const acceptableView = !unacceptableView;
 
+  if (acceptableView) {
+    let view;
+    let feedback; 
+    
+    if (checkSavedStatus(user, recipeID)) {
+      feedback = "Saved"
+    } else {
+      feedback = "Removed"
+    }
+    
+    const feedbacks = {
+      modal: () => showModalFeedback(feedback),
+      grid: () => showGridFeedback(recipeID, feedback)
+    }
+  
+    if (checkIfModalOpen()) {
+      view = "modal";
+    } else {
+      view = "grid";
+    }
+    
+    feedbacks[view]();
+  }
+}
+
+const updateSaveButtons = (recipeID, addButton, removeButton, user) => {
+ 
   if(checkSavedStatus(user, recipeID)){
-    feedback = "Saved"
     addButton.classList.add('hidden');
     removeButton.classList.remove('hidden');
   } else {
-    feedback = "Removed"
     addButton.classList.remove('hidden');
     removeButton.classList.add('hidden');
   }
-
-  const feedbacks = {
-    modal: () => showModalFeedback(feedback),
-    grid: () => showGridFeedback(recipeID, feedback)
-  }
-
-  feedbacks[view]();
 }
 
 const populateRecipeHeader = currentRecipe => {
@@ -494,5 +508,6 @@ export {
   openInfoPanel,
   toggleSavedButtons,
   checkIfModalOpen,
-  showError
+  showError,
+  showFeedback
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,6 +1,6 @@
 //IMPORTS
 import './styles.css'
-import { closePanel, showRecipe, switchView, searchForRecipes, returnHome, updateRecipesFromGrid, toggleTagData, renderActiveTag, displayTaggedRecipes, updateRecipesFromModal, enableScrollPitchText, openInfoPanel, checkIfModalOpen, renderGrid } from './domUpdates';
+import { closePanel, showRecipe, switchView, searchForRecipes, returnHome, updateRecipesFromGrid, toggleTagData, renderActiveTag, displayTaggedRecipes, updateRecipesFromModal, enableScrollPitchText, openInfoPanel, checkIfModalOpen, renderGrid, showFeedback } from './domUpdates';
 import { calculateRecipeCost, getIngredientAmounts, getInstructions } from './recipes';
 import './images/graph.png'
 import './images/refresh.png'
@@ -95,7 +95,9 @@ window.addEventListener('resize', () => {
 })
 
 allRecipes.addEventListener('click', (event) => {
-  updateRecipesFromGrid(event);
+  if (event.target.classList.contains("save-option")) {
+    updateRecipesFromGrid(event);
+  }
 })
 
 modalRecipeBtns.forEach(btn => btn.addEventListener('click', (e) => {


### PR DESCRIPTION
Description
- In my last push, due to change in the order of the functions being called in getUsersAfterUpdate, a new bug was introduced and it went unnoticed. When a recipe would be clicked, it would display the (incorrect) feedback on the grid as the modal would open.
- To fix this, I decoupled the code that displayed feedback from "updateSaveButtons" and made it into a separate function. I would then call this function more intentionally only and everytime a feedback was required. 
- Doing this, caused another bug in "your-recipes" view. The reason was tied up to my last push which changed the order of the functions being called. Because of the change, after deleting any recipe from the "your-recipes" view, some elements' classlists were being rendered undefined and that was causing errors in the console. Fixed it by adding some "?" in the feedback functions. This ensured that an element's existence would be checked before any child is query selected.

Testing Notes
- npm test 
- add/delete recipes on both views. 
- add/delete recipes from both grid and modal on both views.
- add/delete recipes from different screensizes.
- check for server down feedback by turning server off or altering chrome network property.
- just as a caution: ensure that graphs are working as expected.