### PR TITLE
Switch pitch text back to h4

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -83,7 +83,7 @@ const createSingleRecipeHTML = singleRecipe => {
       <div class="recipe-image-div">
         <img class="recipe-image"src="${singleRecipe.image}" alt="${singleRecipe.name}">
         <div class="hover-card">
-          <h3>${singleRecipe.pitch}</h3>
+          <h4>${singleRecipe.pitch}</h4>
         </div>
       </div>
       <h2>${singleRecipe.name}</h2>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -162,7 +162,7 @@ recipeGrid.addEventListener("keyup", (event) => {
 
 recipeGrid.addEventListener("mouseover", (event) => {
   if (event.target.classList?.contains('individual-recipe')) {
-    enableScrollPitchText(event.target.querySelector('h3'));
+    enableScrollPitchText(event.target.querySelector('h4'));
   }
 });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -216,7 +216,7 @@ nav > h1 {
   transition: 0.2s;
 }
 
-.panel > h3 {
+.panel > h4 {
   font-size: 13px;
   border: wheat;  
   height: 0px;
@@ -244,7 +244,7 @@ nav > h1 {
   display: none;
 }
 
-.panel:hover h3 {
+.panel:hover h4 {
   animation: fade-in 0.2s ease-in forwards;
   width: auto;
   height: auto;


### PR DESCRIPTION
For some reason this class was blocking the text scroll for our pitches:
`.individual-recipe:hover h3 {
  animation: fade-in 0.5s ease-in forwards;
}`

Switching our pitch text back to `h4` resulting in a minor hit to our accessibility score.
