### PR TITLE
Add flagsmith and toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chai": "^4.3.4",
     "css-loader": "^5.2.6",
     "file-loader": "^6.2.0",
+    "flagsmith": "^3.18.3",
     "mocha": "^8.4.0",
     "mochapack": "^2.1.2",
     "sass": "^1.34.0",

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -63,10 +63,10 @@ const handleRecipeData = recipes => {
     if (aiEnabled) {
       Promise.all(getChatGPTRecipePitches(pageData.allRecipes))
         .then(() => {
-          updateDataAndRenderPage();
+          preparePageRender();
         });
     } else {
-      updateDataAndRenderPage();
+      preparePageRender();
     }
   });
 }
@@ -80,7 +80,7 @@ const isAIEnabled = () => {
   });
 }
 
-const updateDataAndRenderPage = () => {
+const preparePageRender = () => {
   pageData.recipesOfInterest = copyItem(pageData.allRecipes);
   pageData.allTags = populateTags(pageData.allRecipes);
   hideSpinner();

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -23,9 +23,9 @@ let pageData = {
 let aiEnabled = false;
 
 // API CALLS
-const getUsers = () => fetch('http://localhost:3001/api/v1/users')
-const getRecipes = () => fetch('http://localhost:3001/api/v1/recipes')
-const getIngredients = () => fetch(`http://localhost:3001/api/v1/ingredients`)
+const getUsers = () => fetch('http://localhost:3001/api/v1/users');
+const getRecipes = () => fetch('http://localhost:3001/api/v1/recipes');
+const getIngredients = () => fetch(`http://localhost:3001/api/v1/ingredients`);
 const updateRecipe = (userID, recipeID, request) => {
   const body = {
     userID,
@@ -37,7 +37,7 @@ const updateRecipe = (userID, recipeID, request) => {
     body: JSON.stringify(body),
     headers: {
       'Content-Type': 'application/json'
-  }})
+  }});
 }
 
 const getUsersAfterUpdate = (userID, recipeID, e, errorMessage) => {
@@ -52,40 +52,42 @@ const getUsersAfterUpdate = (userID, recipeID, e, errorMessage) => {
             toggleSavedButtons(e, recipeID, currentUser, errorMessage);
             showFeedback(currentUser, recipeID)
           })
-          .catch(err => console.error(err))
+          .catch(err => console.error(err));
 }
 
-const handleUserData = users => currentUser = getRandomUser(users)
+const handleUserData = users => currentUser = getRandomUser(users);
 
 const handleRecipeData = recipes => {
   pageData.allRecipes = recipes;
-  isAIEnabled();
-  setTimeout(() => {
+  isAIEnabled().then(() => {
     if (aiEnabled) {
-      getChatGPTRecipePitches(pageData.allRecipes);
+      Promise.all(getChatGPTRecipePitches(pageData.allRecipes))
+        .then(() => {
+          pageData.recipesOfInterest = copyItem(pageData.allRecipes);
+          pageData.allTags = populateTags(pageData.allRecipes);
+          hideSpinner();
+          pageLoadRenders(pageData.allRecipes);
+        });
+    } else {
+        pageData.recipesOfInterest = copyItem(pageData.allRecipes);
+        pageData.allTags = populateTags(pageData.allRecipes);
+        hideSpinner();
+        pageLoadRenders(pageData.allRecipes);
     }
-  }, 300)
-  
-  
-  pageData.recipesOfInterest = copyItem(pageData.allRecipes);
-  pageData.allTags = populateTags(pageData.allRecipes);
-  setTimeout(() => {
-    hideSpinner();
-    pageLoadRenders(pageData.allRecipes);
-  }, 2300)
+  });
 }
 
 const isAIEnabled = () => {
-  flagsmith.init({
+  return flagsmith.init({
     environmentID:"KwbANkgyknoDMJgQ4YWxuR",
     onChange: () => {
-        aiEnabled = flagsmith.getState("ai_recipe_pitches").flags.ai_recipe_pitches.enabled
+        aiEnabled = flagsmith.getState("ai_recipe_pitches").flags.ai_recipe_pitches.enabled;
     }
   });
 }
 
 
-const handleIngredientData = ingredients => pageData.allIngredients = ingredients
+const handleIngredientData = ingredients => pageData.allIngredients = ingredients;
 
 const patchHits = (recipe) => {
   fetch('http://localhost:3001/api/v1/recipeHits', {
@@ -104,7 +106,7 @@ const patchHits = (recipe) => {
         .then(res => res.json())
         .then(data => {
           pageData.allRecipes.find(item => item.id === recipe.id).hits = data.recipes.find(item => item.id === recipe.id).hits;
-        })
+        });
     })
 }
 
@@ -176,11 +178,11 @@ const getChatGPTRecipePitches = (allRecipes) => {
     },
   };
 
-  allRecipes.forEach((recipe) => {
+  return allRecipes.map((recipe) => {
     DEFAULT_PARAMS["prompt"] = `In 10 words or less, give me an enticing pitch based on this recipe name: ${recipe.name}`;
     requestOptions.body = JSON.stringify(DEFAULT_PARAMS);
 
-    fetch('https://api.openai.com/v1/completions', requestOptions)
+    return fetch('https://api.openai.com/v1/completions', requestOptions)
         .then(response => response.json())
         .then(data => recipe.pitch = data.choices[0].text)
         .catch(error => console.error(error));

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -63,16 +63,10 @@ const handleRecipeData = recipes => {
     if (aiEnabled) {
       Promise.all(getChatGPTRecipePitches(pageData.allRecipes))
         .then(() => {
-          pageData.recipesOfInterest = copyItem(pageData.allRecipes);
-          pageData.allTags = populateTags(pageData.allRecipes);
-          hideSpinner();
-          pageLoadRenders(pageData.allRecipes);
+          updateDataAndRenderPage();
         });
     } else {
-        pageData.recipesOfInterest = copyItem(pageData.allRecipes);
-        pageData.allTags = populateTags(pageData.allRecipes);
-        hideSpinner();
-        pageLoadRenders(pageData.allRecipes);
+      updateDataAndRenderPage();
     }
   });
 }
@@ -86,6 +80,12 @@ const isAIEnabled = () => {
   });
 }
 
+const updateDataAndRenderPage = () => {
+  pageData.recipesOfInterest = copyItem(pageData.allRecipes);
+  pageData.allTags = populateTags(pageData.allRecipes);
+  hideSpinner();
+  pageLoadRenders(pageData.allRecipes);
+}
 
 const handleIngredientData = ingredients => pageData.allIngredients = ingredients;
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -10,7 +10,8 @@ import {
  } from "./domUpdates";
 import { copyItem } from "./helper-functions";
 import { populateTags } from './recipes';
-// import { config } from "../config.js"
+import { config } from "../config.js";
+import flagsmith from "flagsmith";
 
 // DATA MODEL 
 let currentUser;
@@ -19,6 +20,7 @@ let pageData = {
   currentRecipeCard: {},
   allTags: []
 };
+let aiEnabled = false;
 
 // API CALLS
 const getUsers = () => fetch('http://localhost:3001/api/v1/users')
@@ -57,14 +59,31 @@ const handleUserData = users => currentUser = getRandomUser(users)
 
 const handleRecipeData = recipes => {
   pageData.allRecipes = recipes;
-  // getChatGPTRecipePitches(pageData.allRecipes);
+  isAIEnabled();
+  setTimeout(() => {
+    if (aiEnabled) {
+      getChatGPTRecipePitches(pageData.allRecipes);
+    }
+  }, 300)
+  
+  
   pageData.recipesOfInterest = copyItem(pageData.allRecipes);
   pageData.allTags = populateTags(pageData.allRecipes);
   setTimeout(() => {
     hideSpinner();
     pageLoadRenders(pageData.allRecipes);
-  }, 2000)
+  }, 2300)
 }
+
+const isAIEnabled = () => {
+  flagsmith.init({
+    environmentID:"KwbANkgyknoDMJgQ4YWxuR",
+    onChange: () => {
+        aiEnabled = flagsmith.getState("ai_recipe_pitches").flags.ai_recipe_pitches.enabled
+    }
+  });
+}
+
 
 const handleIngredientData = ingredients => pageData.allIngredients = ingredients
 


### PR DESCRIPTION
## Description
Feature toggling is a VERY important tool for rolling out features efficiently and safely.
This pr adds [Flagsmith](https://docs.flagsmith.com/) feature toggling capabilities to the project and hides our chatGPT call behind such a toggle so we no longer need to make code changes when we want it active/inactive!

## Testing Notes
- Since the flagsmith free tier only allows a single seat per project, you'll need me to physically flip the switch for your testing
  - This is where the actual toggle lives: [ai_recipe_pitches](https://app.flagsmith.com/project/11398/environment/KwbANkgyknoDMJgQ4YWxuR/features?feature=47528)
- with the toggle off, ensure no pitches get generated
- with the toggle on, ai generated pitches should now be visible

## Other Notes
- ~~I spent a couple hours trying to wrap the flagsmith function in a Promise, which in theory could have helped us avoid stacking another `setTimeout` and global assignment for `aiEnabled` but I just couldn't get it to work. I might have been missing something simple? (definitely don't spend too much time going down that rabbit hole...)~~
      We pair-programmed a solution for this and removed all timeouts in our apiCalls!
- the `environmentID` is the flagsmith api key for the entire whats-cookin project. Not terribly sensitive in this case, but definitely something we'd want to migrate over to the more secure area once we have one.
